### PR TITLE
SCT support

### DIFF
--- a/certinfo.go
+++ b/certinfo.go
@@ -632,7 +632,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 
 				for i, sct := range scts {
 					buf.WriteString(fmt.Sprintf("%16sSCT [%d]:\n", "", i))
-					buf.WriteString(fmt.Sprintf("%20sVersion: %d\n", "", sct.SCTVersion))
+					buf.WriteString(fmt.Sprintf("%20sVersion: %s\n", "", sct.SCTVersion))
 					buf.WriteString(fmt.Sprintf("%20sLogID: %s\n", "", toBase64(sct.LogID.KeyID[:])))
 					buf.WriteString(fmt.Sprintf("%20sTimestamp: %d\n", "", sct.Timestamp))
 					// There are no available extensions

--- a/certinfo_test.go
+++ b/certinfo_test.go
@@ -2,10 +2,11 @@ package certinfo
 
 import (
 	"bytes"
-	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
 	"testing"
+
+	"github.com/smallstep/cli/pkg/x509"
 )
 
 type InputType int

--- a/test_certs/leaf2.csr.text
+++ b/test_certs/leaf2.csr.text
@@ -25,7 +25,7 @@ Certificate Request:
                     71:bc:10:a6:45:dd:a0:55:e1:77:02:28:84:58:09:
                     da:f9:ad:16:6e:22:3f:13:f7:91:71:44:5b:5f:98:
                     8c:92:21:13
-    Signature Algorithm: 0
+    Signature Algorithm: DSA-SHA256
          30:2c:02:14:6e:2f:4d:43:42:fe:ef:dd:d6:5d:82:ce:40:35:
          0f:df:f6:03:d0:56:02:14:2c:af:8d:a5:7e:00:cb:18:c9:eb:
          03:ee:9b:92:32:c0:15:73:6a:29


### PR DESCRIPTION
### Description 
This PR adds support for SCT (Signed Certificate Timestamp) extensions. 

With this PR instead of showing:
```
Unknown extension 1.3.6.1.4.1.11129.2.4.2
```
We will display blocks like:
```
RFC6962 Certificate Transparency SCT:
    SCT [0]:
        Version: V1
        LogID: dH7agzGtMxCRIZzOJU9CcMK//V5CIAjGNzV55hB7zFY=
        Timestamp: 1549634864211
        Signature Algorithm: SHA256-ECDSA
            30:44:02:20:3e:cd:76:e7:e4:5a:d8:88:0f:41:49:29:c5:c1:
            89:49:e1:5b:53:97:c3:67:94:d5:94:6c:8a:d9:da:46:a2:f7:
            02:20:65:18:e8:94:69:a5:9f:f7:63:46:aa:51:24:12:9d:bf:
            a1:a1:03:d0:e6:58:6c:b7:b5:2d:3b:cf:9d:1b:10:a0
    SCT [1]:
        Version: V1
        LogID: Y/Lbzeg7zCzPC3KEJ1drM6SNYXePvXWmOLHHaFRL2I0=
        Timestamp: 1549634864270
        Signature Algorithm: SHA256-ECDSA
            30:46:02:21:00:9f:00:ec:e1:df:35:38:5b:cd:43:a2:4a:4e:
            58:f8:93:92:bc:e8:92:27:57:de:ac:83:97:e3:3d:c0:6c:3e:
            ea:02:21:00:dc:08:b0:e5:97:eb:5f:21:27:3e:c1:d6:a1:f8:
            0c:bb:3f:1d:5a:fb:f8:43:11:57:c4:b6:51:99:71:f4:40:32
```