### PR TITLE
Fix space in Yubico Firmware Version

### DIFF
--- a/certinfo.go
+++ b/certinfo.go
@@ -936,7 +936,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 					printSCTSignature(sct.Signature, &buf)
 				}
 			case ext.Id.Equal(oidYubicoFirmwareVersion):
-				printExtensionHeader("X509v3 YubiKey FirmwareVersion", ext, &buf)
+				printExtensionHeader("X509v3 YubiKey Firmware Version", ext, &buf)
 				buf.WriteString(fmt.Sprintf("%16s%s\n", "", yubicoVersion(ext.Value)))
 			case ext.Id.Equal(oidYubicoSerialNumber):
 				var serialNumber int


### PR DESCRIPTION
Noticed this only when trying it with my own:

```console
          Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 YubiKey FirmwareVersion:
                5.1.2
            X509v3 YubiKey Serial Number:
                xxxxxxxx
            X509v3 YubiKey Policy:
                PIN policy: once per session
                Touch policy: never
            X509v3 YubiKey Formfactor:
                USB-A Keychain
    Signature Algorithm: SHA256-RSA
```