### PR TITLE
Remove `github/pkg/errors` dependency

### DIFF
--- a/certinfo.go
+++ b/certinfo.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -21,7 +22,6 @@ import (
 	cttls "github.com/google/certificate-transparency-go/tls"
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 	ctutil "github.com/google/certificate-transparency-go/x509util"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/cryptobyte"
 	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -558,7 +558,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 	// Issuer/Subject Unique ID, typically used in old v2 certificates
 	issuerUID, subjectUID, err := certUniqueIDs(cert.RawTBSCertificate)
 	if err != nil {
-		return "", errors.Errorf("certinfo: Error parsing TBS unique attributes: %v\n", err)
+		return "", fmt.Errorf("certinfo: Error parsing TBS unique attributes: %w", err)
 	}
 	if len(issuerUID) > 0 {
 		buf.WriteString(fmt.Sprintf("%8sIssuer Unique ID: %02x", "", issuerUID[0]))
@@ -857,7 +857,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 				var comment string
 				rest, err := asn1.Unmarshal(ext.Value, &comment)
 				if err != nil || len(rest) > 0 {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 				if ext.Critical {
 					buf.WriteString(fmt.Sprintf("%12sNetscape Comment: critical\n%16s%s\n", "", "", comment))
@@ -874,7 +874,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 				val := &stepProvisioner{}
 				rest, err := asn1.Unmarshal(ext.Value, val)
 				if err != nil || len(rest) > 0 {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 
 				// Get type name
@@ -908,7 +908,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 				val := &stepCertificateAuthority{}
 				rest, err := asn1.Unmarshal(ext.Value, val)
 				if err != nil || len(rest) > 0 {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 				buf.WriteString(fmt.Sprintf("%16sType: %s\n", "", val.Type))
 				if val.CertificateID != "" {
@@ -932,15 +932,15 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 				var raw []byte
 				rest, err := asn1.Unmarshal(ext.Value, &raw)
 				if err != nil || len(rest) > 0 {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 				var sctList ctx509.SignedCertificateTimestampList
 				if rest, err := cttls.Unmarshal(raw, &sctList); err != nil || len(rest) > 0 {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 				scts, err := ctutil.ParseSCTsFromSCTList(&sctList)
 				if err != nil {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 
 				for i, sct := range scts {
@@ -961,7 +961,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 				var serialNumber int
 				rest, err := asn1.Unmarshal(ext.Value, &serialNumber)
 				if err != nil || len(rest) > 0 {
-					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
+					return "", fmt.Errorf("certinfo: Error parsing OID %q", ext.Id.String())
 				}
 				printExtensionHeader("X509v3 YubiKey Serial Number", ext, &buf)
 				buf.WriteString(fmt.Sprintf("%16s%d\n", "", serialNumber))

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/google/certificate-transparency-go v1.1.3
 	github.com/google/go-cmp v0.5.9
-	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d
 )
 


### PR DESCRIPTION
This PR removes the `github.com/pkg/errors` dependency and slightly changes how OID parsing errors are reported.