### PR TITLE
Fix touch policy description

### DIFF
--- a/yubico.go
+++ b/yubico.go
@@ -71,9 +71,9 @@ func yubicoPolicies(v []byte) []string {
 			case 1:
 				policies = append(policies, "Touch policy: never")
 			case 2:
-				policies = append(policies, "Touch policy: once per session")
-			case 3:
 				policies = append(policies, "Touch policy: always")
+			case 3:
+				policies = append(policies, "Touch policy: once per session")
 			default:
 				policies = append(policies, fmt.Sprintf("Touch policy: unknown (0x%02x)", b))
 			}


### PR DESCRIPTION
### Description

This PR fixes the touch policy description when you inspect an attestation certificate of a YubiKey. These are the valid constants for pin and touch policy:

```go
const (
	PINPolicyNever PINPolicy = iota + 1
	PINPolicyOnce
	PINPolicyAlways
)
const (
	TouchPolicyNever TouchPolicy = iota + 1
	TouchPolicyAlways
	TouchPolicyCached
)
```