### PR TITLE
chore: update README example with non-deprecated function from ioutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ import (
   "crypto/x509"
   "encoding/pem"
   "fmt"
-  "io/ioutil"
   "log"
+  "os"
 
   "github.com/smallstep/certinfo"
 )
 
 func main() {
   // Read and parse the PEM certificate file
-  pemData, err := ioutil.ReadFile("cert.pem")
+  pemData, err := os.ReadFile("cert.pem")
   if err != nil {
     log.Fatal(err)
   }


### PR DESCRIPTION
Small PR to update the example in the README that calls the deprecated `ioutil` package (as of [Go 1.16](https://pkg.go.dev/io/ioutil#pkg-overview)) with stdlib equivalent `os.ReadFile()`.

A screenshot just for a sanity check:
![image](https://github.com/smallstep/certinfo/assets/18715356/d5074334-e1a4-44f3-925c-fe6a36a237cb)

Happy New Year!