### PR TITLE
Format serial number bytes with 0 prefix

### DIFF
--- a/certformat.go
+++ b/certformat.go
@@ -72,7 +72,7 @@ func (c *certificateShort) String() string {
 	var buf formatBuffer
 	buf.Writef("X.509v3 %s Certificate (%s) [Serial: %s]\n", c.Type, c.PublicKeyAlgorithm, c.SerialNumber)
 	sans := c.SANs
-	if len(c.Subject) > 0 {
+	if c.Subject != "" {
 		sans = append([]string{c.Subject}, sans...)
 	}
 	if len(sans) == 0 {
@@ -118,7 +118,7 @@ func (c *certificateRequestShort) String() string {
 	var buf formatBuffer
 	buf.Writef("X.509v3 Certificate Signing Request (%s)\n", c.PublicKeyAlgorithm)
 	sans := c.SANs
-	if len(c.Subject) > 0 {
+	if c.Subject != "" {
 		sans = append([]string{c.Subject}, sans...)
 	}
 	if len(sans) == 0 {

--- a/certinfo.go
+++ b/certinfo.go
@@ -649,7 +649,7 @@ func CertificateText(cert *x509.Certificate) (string, error) {
 	fmt.Fprint(buf, "Certificate:\n")
 	fmt.Fprintf(buf, "%4sData:\n", "")
 	printVersion(cert.Version, buf)
-	fmt.Fprintf(buf, "%8sSerial Number: %d (%#x)\n", "", cert.SerialNumber, cert.SerialNumber)
+	fmt.Fprintf(buf, "%8sSerial Number: %d (%#x)\n", "", cert.SerialNumber, cert.SerialNumber.Bytes())
 	fmt.Fprintf(buf, "%4sSignature Algorithm: %s\n", "", cert.SignatureAlgorithm)
 
 	// Issuer information

--- a/test_certs/leaf1.cert.pem
+++ b/test_certs/leaf1.cert.pem
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 2 (0x2)
+        Serial Number: 2 (0x02)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=California, O=World Widget Authority, OU=Identity Affairs, CN=worldwidgetauthority.com/emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf1.cert.text
+++ b/test_certs/leaf1.cert.text
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 2 (0x2)
+        Serial Number: 2 (0x02)
     Signature Algorithm: SHA256-RSA
         Issuer: C=US,ST=California,O=World Widget Authority,OU=Identity Affairs,CN=worldwidgetauthority.com,emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf2.cert.pem
+++ b/test_certs/leaf2.cert.pem
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 3 (0x3)
+        Serial Number: 3 (0x03)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=California, O=World Widget Authority, OU=Identity Affairs, CN=worldwidgetauthority.com/emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf2.cert.text
+++ b/test_certs/leaf2.cert.text
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 3 (0x3)
+        Serial Number: 3 (0x03)
     Signature Algorithm: SHA256-RSA
         Issuer: C=US,ST=California,O=World Widget Authority,OU=Identity Affairs,CN=worldwidgetauthority.com,emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf3.cert.pem
+++ b/test_certs/leaf3.cert.pem
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 4 (0x4)
+        Serial Number: 4 (0x04)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=California, O=World Widget Authority, OU=Identity Affairs, CN=worldwidgetauthority.com/emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf3.cert.text
+++ b/test_certs/leaf3.cert.text
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 4 (0x4)
+        Serial Number: 4 (0x04)
     Signature Algorithm: SHA256-RSA
         Issuer: C=US,ST=California,O=World Widget Authority,OU=Identity Affairs,CN=worldwidgetauthority.com,emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf5.cert.pem
+++ b/test_certs/leaf5.cert.pem
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
+        Serial Number: 1 (0x01)
     Signature Algorithm: sha1WithRSAEncryption
         Issuer: C=US, ST=California, O=World Widget Authority, OU=Identity Affairs, CN=worldwidgetauthority.com/emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/leaf5.cert.text
+++ b/test_certs/leaf5.cert.text
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
+        Serial Number: 1 (0x01)
     Signature Algorithm: SHA1-RSA
         Issuer: C=US,ST=California,O=World Widget Authority,OU=Identity Affairs,CN=worldwidgetauthority.com,emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/root1.cert.pem
+++ b/test_certs/root1.cert.pem
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
+        Serial Number: 1 (0x01)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=California, O=World Widget Authority, OU=Identity Affairs, CN=worldwidgetauthority.com/emailAddress=nobody@worldwidgetauthority.com
         Validity

--- a/test_certs/root1.cert.text
+++ b/test_certs/root1.cert.text
@@ -1,7 +1,7 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
+        Serial Number: 1 (0x01)
     Signature Algorithm: SHA256-RSA
         Issuer: C=US,ST=California,O=World Widget Authority,OU=Identity Affairs,CN=worldwidgetauthority.com,emailAddress=nobody@worldwidgetauthority.com
         Validity


### PR DESCRIPTION
### Description

This commit ensures that the serial number's hexadecimal format shows each byte with 2 hexadecimal digits. The default `big.Int` formatter doesn't prefix the first hexadecimal number with 0 if it is between 1 and F.
