### PR TITLE
Show value for unknown OID in DN

### DIFF
--- a/certinfo.go
+++ b/certinfo.go
@@ -294,6 +294,8 @@ func printName(names []pkix.AttributeTypeAndValue, buf *bytes.Buffer) []string {
 			values = append(values, fmt.Sprintf("DC=%s", name.Value))
 		case oid.Equal(oidUserID):
 			values = append(values, fmt.Sprintf("UID=%s", name.Value))
+		case func() bool { _, ok := name.Value.(string); return ok }():
+			values = append(values, fmt.Sprintf("%s=%s", name.Type.String(), name.Value.(string)))
 		default:
 			values = append(values, fmt.Sprintf("UnknownOID=%s", name.Type.String()))
 		}


### PR DESCRIPTION

#### Pain or issue this feature alleviates:

In case the OID is not known, but the value is a printable string, show the value in the DN. Handling unknown OIDs in general is hard, as they can contain arbitrary data. However, a common case is that that the value is just a printable string, which can easily be represented in the DN.

#### Why is this important to the project (if not answered above):

I have OIDs that are not commonly used in the DN that map to printable strings


PS: If you are interested, I would also be happy to implement a mechanism to register encoders for unknown OIDs.

